### PR TITLE
fix: handle undefined records in case of selectedIndex mismatch

### DIFF
--- a/src/libs/q-a-data-queries.ts
+++ b/src/libs/q-a-data-queries.ts
@@ -42,6 +42,9 @@ export const useQuerySelectedAnswers = () => {
   }
 
   return data.map((record) => {
+    if (record === undefined) {
+      return [];
+    }
     const answers = record.question.reduce<string[]>((prevAnswers, token) => {
       const blankAnswer = readWrite === "read" ? token.hint : token.text;
       return token.isBlank && blankAnswer


### PR DESCRIPTION
シート変更等でデータセットが変わったときに、選択した問題がなくてerrorになっていたのを修正